### PR TITLE
Fixed inclusion of helper TextFieldDateHelper into main app

### DIFF
--- a/lib/formtastic-bootstrap.rb
+++ b/lib/formtastic-bootstrap.rb
@@ -4,3 +4,4 @@ require "formtastic-bootstrap/helpers"
 require "formtastic-bootstrap/inputs"
 require "formtastic-bootstrap/form_builder"
 require "action_view/helpers/text_field_date_helper"
+ActionController::Base.helper ActionView::Helpers::TextFieldDateHelper

--- a/lib/formtastic-bootstrap/inputs/base/labelling.rb
+++ b/lib/formtastic-bootstrap/inputs/base/labelling.rb
@@ -9,6 +9,7 @@ module FormtasticBootstrap
           {}.tap do |opts|
             opts[:for] ||= input_html_options[:id]
             opts[:class] = [opts[:class]]
+            opts[:class] << 'control-label'
           end
         end
         

--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -14,7 +14,8 @@ module FormtasticBootstrap
           fragments.inject([]) do |arr,fragment|
             arr << fragment_input_html(fragment)
            end.join.h
-           
+        end
+        
         def datetime_input_html
           fragments.inject([]) do |arr,fragment|
             arr << " : " if fragment == :minute

--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -10,6 +10,11 @@ module FormtasticBootstrap
           end
         end
 
+        def date_input_html
+          fragments.inject([]) do |arr,fragment|
+            arr << fragment_input_html(fragment)
+           end.join.h
+           
         def datetime_input_html
           fragments.inject([]) do |arr,fragment|
             arr << " : " if fragment == :minute

--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -10,25 +10,20 @@ module FormtasticBootstrap
           end
         end
 
-        def date_input_html
-          fragment_input_html(:date, "small")
-        end
-
-        def time_input_html
-          fragment_input_html(:time, "mini")
-        end
-        
-        def fragment_id(fragment)
-          # TODO is this right?
-          # "#{input_html_options[:id]}_#{position(fragment)}i"
-          "#{input_html_options[:id]}[#{fragment}]"
+        def datetime_input_html
+          fragments.inject([]) do |arr,fragment|
+            arr << " : " if fragment == :minute
+            arr << " - " if fragment == :hour
+            arr << fragment_input_html(fragment)
+            arr
+           end.join.html_safe
         end
         
-        def fragment_input_html(fragment, klass)
-          opts = input_options.merge(:prefix => object_name, :field_name => fragment_name(fragment), :default => value, :include_blank => include_blank?)
-          template.send(:"text_field_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment), :class => klass))
+        def fragment_input_html(fragment)
+          opts = input_options.merge(:prefix => object_name, :field_name => fragment_name(fragment), :default => value, :include_blank => false)
+          template.send(:"select_#{fragment}", value, opts, input_html_options.merge(:id => fragment_id(fragment),:class => "datetime-#{fragment}" ))
         end
-     
+        
       end
     end
   end

--- a/lib/formtastic-bootstrap/inputs/base/timeish.rb
+++ b/lib/formtastic-bootstrap/inputs/base/timeish.rb
@@ -13,7 +13,7 @@ module FormtasticBootstrap
         def date_input_html
           fragments.inject([]) do |arr,fragment|
             arr << fragment_input_html(fragment)
-           end.join.h
+           end.join.html_safe
         end
         
         def datetime_input_html

--- a/lib/formtastic-bootstrap/inputs/datetime_input.rb
+++ b/lib/formtastic-bootstrap/inputs/datetime_input.rb
@@ -9,7 +9,7 @@ module FormtasticBootstrap
         generic_input_wrapping do
           inline_inputs_div_wrapping do
             # This newline matters.
-            date_input_html << "\n".html_safe << time_input_html
+            datetime_input_html
           end
         end
       end


### PR DESCRIPTION
TextFieldDateHelper is not included as a helper in the app because it's
not in the helpers directory. Added a workaround for this as I cannot
figure out how to include it from the Engine without moving it into
helpers directory. I don't really get why TextFieldDateHelper is not in the FormtasticBootstrap::Helpers::InputHelper namespace as these methods
seem to be included fine.

The problem manifests when trying to use a datetime
field, which renders the exception: undefined method `text_field_date'
for #<#<Class..."

Or is there some other way of accomplishing this? I'm running rails 3.1.0, perhaps I should update?
