### PR TITLE
Undo use of 1.9 Hash syntax

### DIFF
--- a/lib/formtastic-bootstrap/inputs/boolean_input.rb
+++ b/lib/formtastic-bootstrap/inputs/boolean_input.rb
@@ -21,7 +21,7 @@ module FormtasticBootstrap
 
       # Need this for formatting to work.
       def empty_label
-        template.content_tag(:label, '', class: 'control-label') do end
+        template.content_tag(:label, '', :class => 'control-label') do end
       end
 
     end


### PR DESCRIPTION
This seemed to be the only location that was using the 1.9 Hash syntax, so I undid that, and everything works fine on 1.8.
