### PR TITLE
changed class of control-group from x to x-wrapper.

### DIFF
--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -49,7 +49,7 @@ module FormtasticBootstrap
             else
               [opts[:class].to_s]
             end
-          opts[:class] << as
+          opts[:class] << "#{as}-wrapper"
           opts[:class] << "control-group"
           # opts[:class] << "input"
           opts[:class] << "error" if errors?

--- a/spec/builder/semantic_fields_for_spec.rb
+++ b/spec/builder/semantic_fields_for_spec.rb
@@ -122,8 +122,8 @@ describe 'FormtasticBootstrap::FormBuilder#fields_for' do
       output_buffer.should have_tag 'input#author_posts_attributes_0_id', :count => 1
     end
 
-    it "should render the hidden input inside an div.hidden" do
-      output_buffer.should have_tag 'div.hidden div.controls input#author_posts_attributes_0_id'
+    it "should render the hidden input inside an div.hidden-wrapper" do
+      output_buffer.should have_tag 'div.hidden-wrapper div.controls input#author_posts_attributes_0_id'
     end
   end
 

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -382,7 +382,7 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
           concat(semantic_form_for(:project, :url => 'http://test.host') do |builder|
             concat(builder.input(:anything))
           end)
-          output_buffer.should have_tag('form div.control-group.string')
+          output_buffer.should have_tag('form div.control-group.string-wrapper')
         end
 
         it 'should default to password for forms without objects if column is password' do
@@ -391,7 +391,7 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
             concat(builder.input(:password_confirmation))
             concat(builder.input(:confirm_password))
           end)
-          output_buffer.should have_tag('form div.control-group.password', :count => 3)
+          output_buffer.should have_tag('form div.control-group.password-wrapper', :count => 3)
         end
 
         it 'should default to a string for methods on objects that don\'t respond to "column_for_attribute"' do
@@ -830,7 +830,7 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :wrapper_html => {:class => :another_class}, :required => true))
           end)
-          output_buffer.should have_tag("form div.control-group.string")
+          output_buffer.should have_tag("form div.control-group.string-wrapper")
           output_buffer.should have_tag("form div.control-group.required")
           output_buffer.should have_tag("form div.control-group.another_class")
         end
@@ -839,7 +839,7 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:title, :wrapper_html => {:class => [ :my_class, :another_class ]}))
           end)
-          output_buffer.should have_tag("form div.control-group.string")
+          output_buffer.should have_tag("form div.control-group.string-wrapper")
           output_buffer.should have_tag("form div.control-group.my_class")
           output_buffer.should have_tag("form div.control-group.another_class")
         end
@@ -893,7 +893,7 @@ describe 'FormtasticBootstrap::FormBuilder#input' do
         concat(builder.input(:title, my_options))
         concat(builder.input(:publish_at, my_options))
       end)
-      output_buffer.should have_tag 'div.control-group.string', :count => 2
+      output_buffer.should have_tag 'div.control-group.string-wrapper', :count => 2
     end
 
   end

--- a/spec/helpers/inputs_helper_spec.rb
+++ b/spec/helpers/inputs_helper_spec.rb
@@ -353,19 +353,19 @@ describe 'Formtastic::FormBuilder#inputs' do
       end
 
       it 'should render a string list item for title' do
-        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string')
+        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string-wrapper')
       end
 
       it 'should render a text list item for body' do
-        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.text')
+        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.text-wrapper')
       end
 
       it 'should render a select list item for author_id' do
-        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.select', :count => 1)
+        output_buffer.should have_tag('form > fieldset.inputs > div.control-group.select-wrapper', :count => 1)
       end
 
       it 'should not render timestamps inputs by default' do
-        output_buffer.should_not have_tag('form > fieldset.inputs > div.control-group.datetime')
+        output_buffer.should_not have_tag('form > fieldset.inputs > div.control-group.datetime-wrapper')
       end
 
       context "with a polymorphic association" do
@@ -398,8 +398,8 @@ describe 'Formtastic::FormBuilder#inputs' do
           end)
 
           output_buffer.should have_tag('form > fieldset.inputs > div.control-group', :count => 2)
-          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string')
-          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.text')
+          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string-wrapper')
+          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.text-wrapper')
         end
       end
 
@@ -409,7 +409,7 @@ describe 'Formtastic::FormBuilder#inputs' do
             concat(builder.inputs(:title, :body))
           end)
 
-          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string', :count => 2)
+          output_buffer.should have_tag('form > fieldset.inputs > div.control-group.string-wrapper', :count => 2)
         end
       end
 

--- a/spec/inputs/boolean_input_spec.rb
+++ b/spec/inputs/boolean_input_spec.rb
@@ -15,7 +15,7 @@ describe 'boolean input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class("boolean")
+  it_should_have_input_wrapper_with_class("boolean-wrapper")
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_allow_comments_input")

--- a/spec/inputs/check_boxes_input_spec.rb
+++ b/spec/inputs/check_boxes_input_spec.rb
@@ -16,7 +16,7 @@ describe 'check_boxes input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("check_boxes")
+    it_should_have_input_wrapper_with_class("check_boxes-wrapper")
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("author_posts_input")

--- a/spec/inputs/date_input_spec.rb
+++ b/spec/inputs/date_input_spec.rb
@@ -20,7 +20,7 @@ describe 'date input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("date")
+    it_should_have_input_wrapper_with_class("date-wrapper")
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place
@@ -31,7 +31,7 @@ describe 'date input' do
     it_should_apply_error_logic_for_input_type(:date)
 
     it 'should have a legend and label with the label text inside the fieldset' do
-      output_buffer.should have_tag('form div.control-group.date label.control-label', /Publish at/)
+      output_buffer.should have_tag('form div.control-group.date-wrapper label.control-label', /Publish at/)
     end
 
     # it 'should associate the legend label with the first select' do
@@ -42,8 +42,8 @@ describe 'date input' do
     # end
 
     it 'should (sort of) associate the label with the input' do
-      output_buffer.should have_tag('form div.control-group.date label.control-label[@for="post_publish_at"]')
-      output_buffer.should have_tag('form div.control-group.date div.controls input[@id="post_publish_at[date]"]')
+      output_buffer.should have_tag('form div.control-group.date-wrapper label.control-label[@for="post_publish_at"]')
+      output_buffer.should have_tag('form div.control-group.date-wrapper div.controls input[@id="post_publish_at[date]"]')
     end
 
     # it 'should have an ordered list of three items inside the fieldset' do
@@ -58,7 +58,7 @@ describe 'date input' do
     #   output_buffer.should have_tag('form li.date fieldset ol li label', /day/i)
     # end
     it 'should have an text input inside the div' do
-      output_buffer.should have_tag('form div.control-group.date div.controls input[@type="text"]')
+      output_buffer.should have_tag('form div.control-group.date-wrapper div.controls input[@type="text"]')
     end
 
     # it 'should have three selects for year, month and day' do

--- a/spec/inputs/datetime_input_spec.rb
+++ b/spec/inputs/datetime_input_spec.rb
@@ -21,7 +21,7 @@ describe 'datetime input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("datetime")
+    it_should_have_input_wrapper_with_class("datetime-wrapper")
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish) # Decide about this.
     it_should_have_input_class_in_the_right_place
@@ -32,7 +32,7 @@ describe 'datetime input' do
     it_should_apply_error_logic_for_input_type(:datetime)
 
     it 'should have a legend and label with the label text inside the fieldset' do
-      output_buffer.should have_tag('form div.control-group.datetime label.control-label', /Publish at/)
+      output_buffer.should have_tag('form div.control-group.datetime-wrapper label.control-label', /Publish at/)
     end
 
     # it 'should associate the legend label with the first select' do
@@ -61,7 +61,7 @@ describe 'datetime input' do
     # end
 
     it 'should have two inputs' do
-      output_buffer.should have_tag('form div.control-group.datetime div.controls input', :count => 2)
+      output_buffer.should have_tag('form div.control-group.datetime-wrapper div.controls input', :count => 2)
     end
 
   end

--- a/spec/inputs/email_input_spec.rb
+++ b/spec/inputs/email_input_spec.rb
@@ -18,7 +18,7 @@ describe 'email input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:email)
+    it_should_have_input_wrapper_with_class('email-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place

--- a/spec/inputs/file_input_spec.rb
+++ b/spec/inputs/file_input_spec.rb
@@ -15,7 +15,7 @@ describe 'file input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class("file")
+  it_should_have_input_wrapper_with_class("file-wrapper")
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_body_input")

--- a/spec/inputs/hidden_input_spec.rb
+++ b/spec/inputs/hidden_input_spec.rb
@@ -19,7 +19,7 @@ describe 'hidden input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class("hidden")
+  it_should_have_input_wrapper_with_class("hidden-wrapper")
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_secret_input")

--- a/spec/inputs/number_input_spec.rb
+++ b/spec/inputs/number_input_spec.rb
@@ -25,7 +25,7 @@ describe 'number input' do
       )
     end
 
-    it_should_have_input_wrapper_with_class(:number)
+    it_should_have_input_wrapper_with_class('number-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:numeric)
     it_should_have_input_wrapper_with_class(:stringish)

--- a/spec/inputs/password_input_spec.rb
+++ b/spec/inputs/password_input_spec.rb
@@ -15,7 +15,7 @@ describe 'password input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class(:password)
+  it_should_have_input_wrapper_with_class('password-wrapper')
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_wrapper_with_class(:stringish)
   it_should_have_input_class_in_the_right_place

--- a/spec/inputs/phone_input_spec.rb
+++ b/spec/inputs/phone_input_spec.rb
@@ -18,7 +18,7 @@ describe 'phone input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:phone)
+    it_should_have_input_wrapper_with_class('phone-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place

--- a/spec/inputs/radio_input_spec.rb
+++ b/spec/inputs/radio_input_spec.rb
@@ -18,7 +18,7 @@ describe 'radio input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("radio")
+    it_should_have_input_wrapper_with_class("radio-wrapper")
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_author_input")

--- a/spec/inputs/range_input_spec.rb
+++ b/spec/inputs/range_input_spec.rb
@@ -18,7 +18,7 @@ describe 'range input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:range)
+    it_should_have_input_wrapper_with_class('range-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:numeric)
     it_should_have_input_wrapper_with_class(:stringish)

--- a/spec/inputs/search_input_spec.rb
+++ b/spec/inputs/search_input_spec.rb
@@ -18,7 +18,7 @@ describe 'search input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:search)
+    it_should_have_input_wrapper_with_class('search-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place

--- a/spec/inputs/select_input_spec.rb
+++ b/spec/inputs/select_input_spec.rb
@@ -140,7 +140,7 @@ describe 'select input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("select")
+    it_should_have_input_wrapper_with_class("select-wrapper")
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_class_in_the_right_place
     it_should_have_input_wrapper_with_id("post_author_input")
@@ -268,7 +268,7 @@ describe 'select input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("select")
+    it_should_have_input_wrapper_with_class("select-wrapper")
     it_should_have_input_wrapper_with_id("post_author_input")
     it_should_have_label_with_text(/Author/)
     it_should_have_label_for('post_author_id')
@@ -318,7 +318,7 @@ describe 'select input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("select")
+    it_should_have_input_wrapper_with_class("select-wrapper")
     it_should_have_input_wrapper_with_id("author_posts_input")
     it_should_have_label_with_text(/Post/)
     it_should_have_label_for('author_post_ids')
@@ -382,7 +382,7 @@ describe 'select input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class("select")
+    it_should_have_input_wrapper_with_class("select-wrapper")
     it_should_have_input_wrapper_with_id("post_authors_input")
     it_should_have_label_with_text(/Author/)
     it_should_have_label_for('post_author_ids')

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -18,7 +18,7 @@ describe 'string input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:string)
+    it_should_have_input_wrapper_with_class('string-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place

--- a/spec/inputs/text_input_spec.rb
+++ b/spec/inputs/text_input_spec.rb
@@ -15,7 +15,7 @@ describe 'text input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class("text")
+  it_should_have_input_wrapper_with_class("text-wrapper")
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_class_in_the_right_place
   it_should_have_input_wrapper_with_id("post_body_input")

--- a/spec/inputs/time_input_spec.rb
+++ b/spec/inputs/time_input_spec.rb
@@ -68,7 +68,7 @@ describe 'time input' do
         end)
       end
 
-      it_should_have_input_wrapper_with_class("time")
+      it_should_have_input_wrapper_with_class("time-wrapper")
       it_should_have_input_wrapper_with_class("control-group")
       it_should_have_input_wrapper_with_class(:stringish)
       it_should_have_input_class_in_the_right_place
@@ -77,17 +77,17 @@ describe 'time input' do
       it_should_apply_error_logic_for_input_type(:time)
 
       it 'should have a legend and label with the label text inside the fieldset' do
-        output_buffer.should have_tag('form div.control-group.time label.control-label', /Publish at/)
+        output_buffer.should have_tag('form div.control-group.time-wrapper label.control-label', /Publish at/)
       end
 
       # TODO Is this right?
       it 'should (sort of) associate the label with the input' do
-        output_buffer.should have_tag('form div.control-group.time label.control-label[@for="post_publish_at"]')
-        output_buffer.should have_tag('form div.control-group.time div.controls input[@id="post_publish_at[time]"]')
+        output_buffer.should have_tag('form div.control-group.time-wrapper label.control-label[@for="post_publish_at"]')
+        output_buffer.should have_tag('form div.control-group.time-wrapper div.controls input[@id="post_publish_at[time]"]')
       end
 
       it 'should have an text input inside the div' do
-        output_buffer.should have_tag('form div.control-group.time div.controls input[@type="text"]')
+        output_buffer.should have_tag('form div.control-group.time-wrapper div.controls input[@type="text"]')
       end
 
       # it 'should have five labels for hour and minute' do

--- a/spec/inputs/time_zone_input_spec.rb
+++ b/spec/inputs/time_zone_input_spec.rb
@@ -15,7 +15,7 @@ describe 'time_zone input' do
     end)
   end
 
-  it_should_have_input_wrapper_with_class("time_zone")
+  it_should_have_input_wrapper_with_class("time_zone-wrapper")
   it_should_have_input_wrapper_with_class("control-group")
   it_should_have_input_wrapper_with_id("post_time_zone_input")
   it_should_apply_error_logic_for_input_type(:time_zone)

--- a/spec/inputs/url_input_spec.rb
+++ b/spec/inputs/url_input_spec.rb
@@ -18,7 +18,7 @@ describe 'url input' do
       end)
     end
 
-    it_should_have_input_wrapper_with_class(:url)
+    it_should_have_input_wrapper_with_class('url-wrapper')
     it_should_have_input_wrapper_with_class("control-group")
     it_should_have_input_wrapper_with_class(:stringish)
     it_should_have_input_class_in_the_right_place

--- a/spec/support/custom_macros.rb
+++ b/spec/support/custom_macros.rb
@@ -324,7 +324,7 @@ module CustomMacros
           concat(semantic_form_for(@new_post) do |builder|
             concat(builder.input(:author, :as => as, :collection => @authors))
           end)
-          output_buffer.should have_tag("form div.#{as} #{countable}", :count => @authors.size + (as == :select ? 1 : 0))
+          output_buffer.should have_tag("form div.#{as}-wrapper #{countable}", :count => @authors.size + (as == :select ? 1 : 0))
         end
 
         describe 'and the :collection is an array of strings' do
@@ -338,8 +338,8 @@ module CustomMacros
             end)
 
             @categories.each do |value|
-              output_buffer.should have_tag("form div.#{as}", /#{value}/)
-              output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{value}']")
+              output_buffer.should have_tag("form div.#{as}-wrapper", /#{value}/)
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{value}']")
             end
           end
 
@@ -371,8 +371,8 @@ module CustomMacros
             end)
 
             @categories.each do |label, value|
-              output_buffer.should have_tag("form div.#{as}", /#{label}/)
-              output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{value}']")
+              output_buffer.should have_tag("form div.#{as}-wrapper", /#{label}/)
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{value}']")
             end
           end
         end
@@ -389,9 +389,9 @@ module CustomMacros
 
             @categories.each do |text, value|
               label = as == :select ? :option : :label
-              output_buffer.should have_tag("form div.#{as} #{label}", /#{text}/i)
-              output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{value.to_s}']")
-              output_buffer.should have_tag("form div.#{as} #{countable}#post_category_name_#{value.to_s}") if as == :radio
+              output_buffer.should have_tag("form div.#{as}-wrapper #{label}", /#{text}/i)
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{value.to_s}']")
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}#post_category_name_#{value.to_s}") if as == :radio
             end
           end
         end
@@ -407,8 +407,8 @@ module CustomMacros
                 concat(builder.input(:category_name, :as => as, :collection => @choices))
               end)
 
-              output_buffer.should have_tag("form div.#{as} #{countable}#post_category_name_true")
-              output_buffer.should have_tag("form div.#{as} #{countable}#post_category_name_false")
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}#post_category_name_true")
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}#post_category_name_false")
             end
           end
         end
@@ -425,8 +425,8 @@ module CustomMacros
 
             @categories.each do |value|
               label = as == :select ? :option : :label
-              output_buffer.should have_tag("form div.#{as} #{label}", /#{value}/i)
-              output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{value.to_s}']")
+              output_buffer.should have_tag("form div.#{as}-wrapper #{label}", /#{value}/i)
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{value.to_s}']")
             end
           end
         end
@@ -442,8 +442,8 @@ module CustomMacros
             end)
 
             @categories.each do |label, value|
-              output_buffer.should have_tag("form div.#{as}", /#{label}/)
-              output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{value}']")
+              output_buffer.should have_tag("form div.#{as}-wrapper", /#{label}/)
+              output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{value}']")
             end
           end
 
@@ -460,7 +460,7 @@ module CustomMacros
 
             it 'should have options with text content from the specified method' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as}", /#{author.login}/)
+                output_buffer.should have_tag("form div.#{as}-wrapper", /#{author.login}/)
               end
             end
           end
@@ -474,7 +474,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as}", /#{author.login.reverse}/)
+                output_buffer.should have_tag("form div.#{as}-wrapper", /#{author.login.reverse}/)
               end
             end
           end
@@ -491,7 +491,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as}", /#{author.login.reverse}/)
+                output_buffer.should have_tag("form div.#{as}-wrapper", /#{author.login.reverse}/)
               end
             end
           end
@@ -512,7 +512,7 @@ module CustomMacros
 
               it "should render the options with #{label_method} as the label" do
                 ::Author.all.each do |author|
-                  output_buffer.should have_tag("form div.#{as}", /The Label Text/)
+                  output_buffer.should have_tag("form div.#{as}-wrapper", /The Label Text/)
                 end
               end
             end
@@ -531,7 +531,7 @@ module CustomMacros
 
             it 'should have options with values from specified method' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{author.login}']")
+                output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{author.login}']")
               end
             end
           end
@@ -545,7 +545,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each value' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{author.login.reverse}']")
+                output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{author.login.reverse}']")
               end
             end
           end
@@ -562,7 +562,7 @@ module CustomMacros
 
             it 'should have options with the proc applied to each value' do
               ::Author.all.each do |author|
-                output_buffer.should have_tag("form div.#{as} #{countable}[@value='#{author.login.reverse}']")
+                output_buffer.should have_tag("form div.#{as}-wrapper #{countable}[@value='#{author.login.reverse}']")
               end
             end
           end


### PR DESCRIPTION
x can be any input type.

This is needed, because some classes (especially 'radio') are also defined by bootstrap with another meaning/styling.
