### PR TITLE
Better support for Prepended and Appended input text

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,53 +47,59 @@ made to generate the HTML expected by Bootstrap while still generating the rich 
 
 #### ERB
 
-    <%= semantic_form_for @post do |f| %>
-      <%= f.semantic_errors %>
-      <%= f.inputs do %>
-        <%= f.input :title, :hint => "This is the title!" %>
-      <% end %>
-      <%= f.buttons do %>
-        <%= f.commit_button %>
-      <% end %>
-    <% end %>
+```html+erb
+<%= semantic_form_for @post do |f| %>
+  <%= f.semantic_errors %>
+  <%= f.inputs do %>
+    <%= f.input :title, :hint => "This is the title!" %>
+  <% end %>
+  <%= f.buttons do %>
+    <%= f.commit_button %>
+  <% end %>
+<% end %>
+```
 
 #### Formtastic
 
-    <form accept-charset="UTF-8" action="/posts" class="formtastic post" id="new_post" method="post">
-      <fieldset class="inputs">
-        <ol>
-          <li class="string input optional stringish" id="post_title_input">
-            <label class=" label" for="post_title">Title</label>
-            <input id="post_title" maxlength="255" name="post[title]" type="text" value="" />
-            <p class="inline-hints">This is the title!</p>
-          </li>
-        </ol>
-      </fieldset>
-      <fieldset class="buttons">
-        <ol>
-          <li class="commit button">
-            <input class="create" name="commit" type="submit" value="Create Post" />
-          </li>
-        </ol>
-      </fieldset>
-    </form>
+```html
+<form accept-charset="UTF-8" action="/posts" class="formtastic post" id="new_post" method="post">
+  <fieldset class="inputs">
+    <ol>
+      <li class="string input optional stringish" id="post_title_input">
+        <label class=" label" for="post_title">Title</label>
+        <input id="post_title" maxlength="255" name="post[title]" type="text" value="" />
+        <p class="inline-hints">This is the title!</p>
+      </li>
+    </ol>
+  </fieldset>
+  <fieldset class="buttons">
+    <ol>
+      <li class="commit button">
+        <input class="create" name="commit" type="submit" value="Create Post" />
+      </li>
+    </ol>
+  </fieldset>
+</form>
+```
 
 #### Formtastic Bootstrap
 
-    <form accept-charset="UTF-8" action="/posts" class="formtastic post" id="new_post" method="post">
-      <fieldset class="inputs">
-        <div class="string clearfix optional stringish" id="post_title_input">
-          <label class="" for="post_title">Title</label>
-          <div class="input">
-            <input id="post_title" maxlength="255" name="post[title]" type="text" value="" />
-            <span class="help-inline">This is the title!</span>
-          </div>
-        </div>
-      </fieldset>
-      <div class="actions">
-        <input class="btn create commit" name="commit" type="submit" value="Create Post" />
+```html
+<form accept-charset="UTF-8" action="/posts" class="formtastic post" id="new_post" method="post">
+  <fieldset class="inputs">
+    <div class="string clearfix optional stringish" id="post_title_input">
+      <label class="" for="post_title">Title</label>
+      <div class="input">
+        <input id="post_title" maxlength="255" name="post[title]" type="text" value="" />
+        <span class="help-inline">This is the title!</span>
       </div>
-    </form>
+    </div>
+  </fieldset>
+  <div class="actions">
+    <input class="btn create commit" name="commit" type="submit" value="Create Post" />
+  </div>
+</form>
+```
 
 ### Major Difference in Behavior
 
@@ -131,14 +137,17 @@ Contributions are welcome!
 
 ## Usage
 
-#### Prepended Text
-To create a Prepended Text field, use the ```:prepend``` option.  This works on any text field input type, like ```:url```, ```:search```, and of course ```:string```
+#### Prepended or Appended Text
+To create a Prepended or Appended Text field, use the <tt>:prepend</tt> or <tt>:append</tt> option, respectively. This works on any text field input type, like <tt>:url</tt>, <tt>:search</tt>, and of course <tt>:string</tt>. Prepend and appand can be combined to wrap an input:
 
-    <%= semantic_form_for @user do |f| %>
-      <%= f.inputs do %>
-        <%= f.input :handle, :prepend => '@' %>
-      <% end %>
-    <% end %>
+```html+erb
+<%= semantic_form_for @user do |f| %>
+  <%= f.inputs do %>
+    <%= f.input :handle, :prepend => '@' %>
+    <%= f.input :dollars, :prepend => '$', :append => '.00' %>
+  <% end %>
+<% end %>
+```
 
 ## Contributing
  

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Formtastic Bootstrap
 
-A [Formtastic](https://github.com/justinfrench/formtastic) form builder that creates markup suitable for the [Twitter Bootstrap](http://twitter.github.com/bootstrap/) framework.  In theory, it should just work.  Two great tastes in one!
-
-You can follow [FormBoot on twitter](http://twitter.com/FormBoot) for update announcements and other relevant info.
+A [Formtastic](https://github.com/justinfrench/formtastic) form builder that creates markup suitable for the [Twitter Bootstrap](http://twitter.github.com/bootstrap/) framework.
 
 ## Getting Started
 
 ### Dependencies
 
-Formtastic Bootstrap has only been tested with Ruby 1.9.2, Rails 3.1, Formtastic 2.0 and Twitter Bootstrap 1.3.
+ * Formtastic 2.1+
+ * Bootstrap 2.0+
 
 #### Installation
 
@@ -16,7 +15,7 @@ Install the gem with
 
     gem install formtastic-bootstrap
 
-Or add it to your Gemfile:
+Or add it to your Gemfile (*note*: must be included after Formtastic):
 
     gem 'formtastic-bootstrap'
 
@@ -34,16 +33,14 @@ Add the following line to the top of your <tt>application.css</tt> file:
     # app/assets/stylesheets/application.css
     *= require formtastic-bootstrap
 
-Make sure you've already downloaded and installed Formtastic!
-
 
 ## Formtastic vs. Formtastic Bootstrap
 
 
 ### Overview
 
-In general, Formtastic creates very verbose HTML whereas Bootstrap expects simpler HTML.  Every attempt has been
-made to generate the HTML expected by Bootstrap while still generating the rich HTML provided by Formtastic.  Here's a pretty typical (simplified) example of what Formtastic generates and what Formtastic Bootstrap generates.
+In general, Formtastic creates very verbose HTML whereas Bootstrap expects simpler HTML. Every attempt has been
+made to generate the HTML expected by Bootstrap while still generating the rich HTML provided by Formtastic. Here's a pretty typical (simplified) example of what Formtastic generates and what Formtastic Bootstrap generates:
 
 #### ERB
 
@@ -113,7 +110,7 @@ made to generate the HTML expected by Bootstrap while still generating the rich 
 
 Bootstrap is somewhat incomplete, and in a few cases an inference needed to be drawn to determine a course of action.  If you disagree with any of these choices, feel free to let me know.
 
-The gem also provides some "shim" CSS where Bootstrap is missing styles provided Formtastic.
+The gem also provides some "shim" CSS where Bootstrap is missing styles provided Formtastic. **NOTE:** The Twitter Bootstrap CSS is not included.
 
 ### Other
 
@@ -133,11 +130,12 @@ In particular:
 Contributions are welcome!
 
 * Formtastic's <tt>:country</tt> has not yet been implemented.
-* Twitter Bootstrap's Date Range, Prepend Checkbox and Appended Checkbox controls have not yet been implemented.
+* Twitter Bootstrap's Date Range, Prepend *Checkbox* and Appended *Checkbox* controls have not yet been implemented.
 
 ## Usage
 
 #### Prepended or Appended Text
+
 To create a Prepended or Appended Text field, use the <tt>:prepend</tt> or <tt>:append</tt> option, respectively. This works on any text field input type, like <tt>:url</tt>, <tt>:search</tt>, and of course <tt>:string</tt>. Prepend and appand can be combined to wrap an input:
 
 ```html+erb
@@ -153,7 +151,7 @@ To create a Prepended or Appended Text field, use the <tt>:prepend</tt> or <tt>:
  
 ### Contributors
 
-A big thank you [to all contributors](https://github.com/mjbellantoni/formtastic-bootstrap/contributors)!
+A big thank you [to all contributors](./contributors)!
 
 ### Submitting Issues
 

--- a/lib/formtastic-bootstrap/inputs.rb
+++ b/lib/formtastic-bootstrap/inputs.rb
@@ -18,6 +18,7 @@ require "formtastic-bootstrap/inputs/text_input"
 require "formtastic-bootstrap/inputs/time_input"
 require "formtastic-bootstrap/inputs/time_zone_input"
 require "formtastic-bootstrap/inputs/url_input"
+require "formtastic-bootstrap/inputs/country_input"
 
 module FormtasticBootstrap
   module Inputs

--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -13,6 +13,10 @@ module FormtasticBootstrap
                 prepended_input_wrapping do
                   [template.content_tag(:span, options[:prepend], :class => 'add-on'), yield].join("\n").html_safe
                 end
+              elsif options[:append]
+                appended_input_wrapping do
+                  [yield, template.content_tag(:span, options[:append], :class => 'add-on')].join("\n").html_safe
+                end
               else
                 yield
               end
@@ -65,6 +69,12 @@ module FormtasticBootstrap
         
         def prepended_input_wrapping(&block)
           template.content_tag(:div, :class => 'input-prepend') do
+            yield
+          end
+        end
+        
+        def appended_input_wrapping(&block)
+          template.content_tag(:div, :class => 'input-append') do
             yield
           end
         end

--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -9,19 +9,30 @@ module FormtasticBootstrap
           control_group_div_wrapping do
             label_html <<
             input_div_wrapping do
-              if options[:prepend]
-                prepended_input_wrapping do
-                  [template.content_tag(:span, options[:prepend], :class => 'add-on'), yield].join('').html_safe
+              if options[:prepend] || options[:append]
+                content = [yield]
+                wrapper_classes = []
+                
+                if options[:prepend]
+                  content.unshift input_add_on(options[:prepend])
+                  wrapper_classes << 'input-prepend'
                 end
-              elsif options[:append]
-                appended_input_wrapping do
-                  [yield, template.content_tag(:span, options[:append], :class => 'add-on')].join('').html_safe
+
+                if options[:append]
+                  content << input_add_on(options[:append])
+                  wrapper_classes << 'input-append'
                 end
+                
+                template.content_tag(:div, content.join.html_safe, :class => wrapper_classes)
               else
                 yield
               end
             end
           end
+        end
+        
+        def input_add_on(content)
+          template.content_tag(:span, content, :class => 'add-on')
         end
 
         def control_group_div_wrapping(&block)
@@ -66,19 +77,8 @@ module FormtasticBootstrap
 
           opts
         end
-        
-        def prepended_input_wrapping(&block)
-          template.content_tag(:div, :class => 'input-prepend') do
-            yield
-          end
-        end
-        
-        def appended_input_wrapping(&block)
-          template.content_tag(:div, :class => 'input-append') do
-            yield
-          end
-        end
       end
+      
     end
   end
 end

--- a/lib/formtastic-bootstrap/inputs/base/wrapping.rb
+++ b/lib/formtastic-bootstrap/inputs/base/wrapping.rb
@@ -11,11 +11,11 @@ module FormtasticBootstrap
             input_div_wrapping do
               if options[:prepend]
                 prepended_input_wrapping do
-                  [template.content_tag(:span, options[:prepend], :class => 'add-on'), yield].join("\n").html_safe
+                  [template.content_tag(:span, options[:prepend], :class => 'add-on'), yield].join('').html_safe
                 end
               elsif options[:append]
                 appended_input_wrapping do
-                  [yield, template.content_tag(:span, options[:append], :class => 'add-on')].join("\n").html_safe
+                  [yield, template.content_tag(:span, options[:append], :class => 'add-on')].join('').html_safe
                 end
               else
                 yield

--- a/lib/formtastic-bootstrap/inputs/country_input.rb
+++ b/lib/formtastic-bootstrap/inputs/country_input.rb
@@ -1,0 +1,12 @@
+module FormtasticBootstrap
+  module Inputs
+    class CountryInput < Formtastic::Inputs::CountryInput
+      include Base
+      def to_html
+        generic_input_wrapping do
+          builder.country_select(method, priority_countries, input_options, input_html_options)
+        end
+      end
+    end
+  end
+end

--- a/spec/inputs/string_input_spec.rb
+++ b/spec/inputs/string_input_spec.rb
@@ -222,6 +222,24 @@ describe 'string input' do
       output_buffer.should have_tag('form div.control-group div.controls div.input-prepend input[name="user[handle]"]')
     end
   end
+  
+  describe "with string appended", :now => true do
+
+    before do
+      concat(semantic_form_for(:user) do |builder|
+        concat(builder.input(:handle, :as => :string, :append => '@'))
+      end)
+    end
+
+    it "should generate span with desired append string" do
+      output_buffer.should have_tag('form div.control-group div.controls div.input-append span.add-on', '@')
+    end
+
+    it "should wrap input in div.input-append" do
+      output_buffer.should have_tag('form div.control-group div.controls div.input-append input[name="user[handle]"]')
+    end
+  end
+  
 
 end
 

--- a/vendor/assets/stylesheets/formtastic-bootstrap.css
+++ b/vendor/assets/stylesheets/formtastic-bootstrap.css
@@ -1,3 +1,5 @@
+/*Formtastic Bootstrap*/
+
 .hidden {
 	display: none;
 }

--- a/vendor/assets/stylesheets/formtastic-bootstrap.css
+++ b/vendor/assets/stylesheets/formtastic-bootstrap.css
@@ -3,3 +3,13 @@
 .hidden {
 	display: none;
 }
+
+/*
+  Formtastic's helper .radio and .checkbox classes on the .control-group cause 
+  problems with the padding on the actual input elements of those types. This
+  resolves the issue without affecting compatibility with Formtastic.
+*/
+.control-group.radio,
+.control-group.checkbox {
+  padding-left: 0;
+}


### PR DESCRIPTION
Prepended inputs were broken due to whitespace between the add-on and the input element, and appended elements weren't present. This resolves both, and allows for both prepended and appended elements on the same element (i.e. exactly what is supported, though I didn't get into adding fancy appended buttons).

**EDIT**: Also pulled in country input from @macteo and updated the README accordingly.
